### PR TITLE
Add support to use lock in a enviroment with CGLib proxies.

### DIFF
--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
@@ -56,9 +56,7 @@ public class DistributedLockConfiguration {
         try {
           return (Lock) advised.getTargetSource().getTarget();
         } catch (final Exception e) {
-          final String msgError = "Can't get lock type from AOP Proxy";
-          log.error(msgError, e);
-          throw new DistributedLockException(msgError, e);
+          throw new DistributedLockException("Can't get lock type from AOP Proxy", e);
         }
       }
       return lock;


### PR DESCRIPTION
I need to do this fix because we have the Springboot configuration proxy-target-class: true

When the Lock bean is provided by CGLib, the get form map fails because the class isn't the same for the wrapper proxy object.