### PR TITLE
MySQL 5.7.22 key is a reserved word

### DIFF
--- a/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
+++ b/distributed-lock-core/src/main/java/com/github/alturkovic/lock/configuration/DistributedLockConfiguration.java
@@ -56,9 +56,7 @@ public class DistributedLockConfiguration {
         try {
           return (Lock) advised.getTargetSource().getTarget();
         } catch (final Exception e) {
-          final String msgError = "Can't get lock type from AOP Proxy";
-          log.error(msgError, e);
-          throw new DistributedLockException(msgError, e);
+          throw new DistributedLockException("Can't get lock type from AOP Proxy", e);
         }
       }
       return lock;

--- a/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/service/SimpleJdbcLockSingleKeyService.java
+++ b/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/service/SimpleJdbcLockSingleKeyService.java
@@ -39,9 +39,9 @@ import java.util.Date;
 @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 public class SimpleJdbcLockSingleKeyService implements JdbcLockSingleKeyService {
 
-  private static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO %s (key, token, expireAt) VALUES (?, ?, ?);";
-  private static final String RELEASE_FORMATTED_QUERY = "DELETE FROM %s WHERE key = ? AND token = ?;";
-  private static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM %s WHERE expireAt < ?;";
+  private static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO %s (`key`, token, expireAt) VALUES (?, ?, ?);";
+  private static final String RELEASE_FORMATTED_QUERY = "DELETE FROM %s WHERE `key` = ? AND token = ?";
+  private static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM %s WHERE expireAt < ?";
 
   private final JdbcTemplate jdbcTemplate;
 

--- a/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/service/SimpleJdbcLockSingleKeyService.java
+++ b/distributed-lock-jdbc/src/main/java/com/github/alturkovic/lock/jdbc/service/SimpleJdbcLockSingleKeyService.java
@@ -39,9 +39,9 @@ import java.util.Date;
 @Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 public class SimpleJdbcLockSingleKeyService implements JdbcLockSingleKeyService {
 
-  private static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO %s (key, token, expireAt) VALUES (?, ?, ?)";
-  private static final String RELEASE_FORMATTED_QUERY = "DELETE FROM %s WHERE key = ? AND token = ?";
-  private static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM %s WHERE expireAt < ?";
+  private static final String ACQUIRE_FORMATTED_QUERY = "INSERT INTO %s (key, token, expireAt) VALUES (?, ?, ?);";
+  private static final String RELEASE_FORMATTED_QUERY = "DELETE FROM %s WHERE key = ? AND token = ?;";
+  private static final String DELETE_EXPIRED_FORMATTED_QUERY = "DELETE FROM %s WHERE expireAt < ?;";
 
   private final JdbcTemplate jdbcTemplate;
 


### PR DESCRIPTION
We upgrade our MySQL database and key is a reserved word on this version, we need to scape key word to work, otherwise we get a SQL Grammar Syntax Error.